### PR TITLE
Cache ghc and cabal dirs to reduce build times

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,8 @@ language: c
 sudo: false
 cache:
   directories:
-  - $HOME/.cabal/packages
+  - $HOME/.cabal
+  - $HOME/.ghc
 before_cache:
 - rm -fv $HOME/.cabal/packages/hackage.haskell.org/00-index.tar
 - rm -fv $HOME/.cabal/packages/hackage.haskell.org/build-reports.log
@@ -18,13 +19,11 @@ env:
 - - CABALVER=1.22
   - GHCVER=7.10.1
 before_install:
-- bash _scripts/install.sh
-- export PATH=$HOME/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
+  - bash _scripts/pre_install.sh
+  - export PATH=$HOME/.cabal/bin:/opt/ghc/$GHCVER/bin:/opt/cabal/$CABALVER/bin:$PATH
 install:
-- cabal sandbox init
-- cabal update
-- cabal install --only-dependencies
+  - bash _scripts/install.sh
 script:
-- cabal run build
+  - cabal run build
 after_success:
   - bash _scripts/deploy.sh

--- a/_scripts/install.sh
+++ b/_scripts/install.sh
@@ -2,7 +2,5 @@
 
 set -x
 
-openssl aes-256-cbc -K $encrypted_2fcc66f61dc1_key -iv $encrypted_2fcc66f61dc1_iv -in deploy-key.enc -out deploy-key -d
-rm deploy-key.enc
-chmod 600 deploy-key
-mv deploy-key ~/.ssh/id_rsa
+cabal update
+cabal install --only-dependencies

--- a/_scripts/pre_install.sh
+++ b/_scripts/pre_install.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -x
+
+openssl aes-256-cbc -K $encrypted_2fcc66f61dc1_key -iv $encrypted_2fcc66f61dc1_iv -in deploy-key.enc -out deploy-key -d
+rm deploy-key.enc
+chmod 600 deploy-key
+mv deploy-key ~/.ssh/id_rsa


### PR DESCRIPTION
This caches `$HOME/.ghc` and `$HOME/.cabal` to reduce build times from
~25 minutes to ~2 minutes (long build times caused by building all of
the dependencies of the project each time).

Additionally, I'm no longer building in a cabal sandbox. Sandboxing
isn't needed on the CI instance.